### PR TITLE
Automated install steps + new IndexedDB plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+**/*~
+**/._*
+**/.DS_Store
+.idea
+npm-debug.log
+node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+**/*~
+**/._*
+**/.DS_Store
+.idea
+npm-debug.log
+node_modules
+/.*

--- a/README.MD
+++ b/README.MD
@@ -17,7 +17,7 @@ Add SDK references to the .Phone.jsproj:
   <When Condition="$(Platform) == 'x86'">
     <ItemGroup>
       <Reference Include="SQLitePluginNative">
-        <HintPath>..\..\plugins\com.thinkwisesoftware.websql\dist\x86\SQLitePluginNative.winmd</HintPath>
+        <HintPath>..\..\plugins\cordova-plugin-websql-async\dist\x86\SQLitePluginNative.winmd</HintPath>
         <IsWinMDFile>true</IsWinMDFile>
       </Reference>
     </ItemGroup>
@@ -25,7 +25,7 @@ Add SDK references to the .Phone.jsproj:
   <When Condition="$(Platform) == 'ARM'">
     <ItemGroup>
       <Reference Include="SQLitePluginNative">
-        <HintPath>..\..\plugins\com.thinkwisesoftware.websql\dist\ARM\SQLitePluginNative.winmd</HintPath>
+        <HintPath>..\..\plugins\cordova-plugin-websql-async\dist\ARM\SQLitePluginNative.winmd</HintPath>
         <IsWinMDFile>true</IsWinMDFile>
       </Reference>
     </ItemGroup>
@@ -37,7 +37,7 @@ Add the following to expand the SDKReferenceDirectoryRoot. Its important that th
 <!-- Last import element -->
 <PropertyGroup>
   <SDKReferenceDirectoryRoot>
-    ..\..\plugins\com.thinkwisesoftware.websql\src\windows\SDK\;$(SDKReferenceDirectoryRoot);
+    ..\..\plugins\cordova-plugin-websql-async\src\windows\SDK\;$(SDKReferenceDirectoryRoot);
   </SDKReferenceDirectoryRoot>
 </PropertyGroup>
 ```

--- a/README.MD
+++ b/README.MD
@@ -1,49 +1,23 @@
 # WebSQL plugin for Apache Cordova (Windows Phone)
-Enables WebSQL functionality on top of a Sqlite library. This repo is based on the [WebSQL plugin](https://github.com/MSOpenTech/cordova-plugin-websql) of MSOpenTech. This plugin however supports async execution of sql where the WebSQL plugin of MSOpenTech is completely sync.
+Enables WebSQL functionality on top of a SQLite library. This repo is based on the [WebSQL plugin](https://github.com/MSOpenTech/cordova-plugin-websql) of MSOpenTech. This plugin however supports async execution of sql where the WebSQL plugin of MSOpenTech is completely sync.
 
 ## Usage
-This plugin is used with the IndexedDBShim which can be found [here](https://github.com/axemclion/IndexedDBShim). This basically provides an IndexedDb interface on top of the WebSql interface.
+This plugin is intended to be combined with the [asynchronous IndexedDB plugin](https://github.com/ABB-Austin/cordova-plugin-indexeddb-async). This provides an IndexedDB interface on top of the WebSql interface.
 
-## Installation guide
-Add SDK references to the .Phone.jsproj:
-```xml
-<ItemGroup>
-  <SDKReference Include="Microsoft.VCLibs, Version=12.0" />
-</ItemGroup>
-<ItemGroup>
-  <SDKReference Include="SQLite.WP81, Version=3.8.8.1" />
-</ItemGroup>
-<Choose>
-  <When Condition="$(Platform) == 'x86'">
-    <ItemGroup>
-      <Reference Include="SQLitePluginNative">
-        <HintPath>..\..\plugins\cordova-plugin-websql-async\dist\x86\SQLitePluginNative.winmd</HintPath>
-        <IsWinMDFile>true</IsWinMDFile>
-      </Reference>
-    </ItemGroup>
-  </When>
-  <When Condition="$(Platform) == 'ARM'">
-    <ItemGroup>
-      <Reference Include="SQLitePluginNative">
-        <HintPath>..\..\plugins\cordova-plugin-websql-async\dist\ARM\SQLitePluginNative.winmd</HintPath>
-        <IsWinMDFile>true</IsWinMDFile>
-      </Reference>
-    </ItemGroup>
-  </When>
-</Choose>
-```
-Add the following to expand the SDKReferenceDirectoryRoot. Its important that the XML is added right after the last Import element.
-```xml
-<!-- Last import element -->
-<PropertyGroup>
-  <SDKReferenceDirectoryRoot>
-    ..\..\plugins\cordova-plugin-websql-async\src\windows\SDK\;$(SDKReferenceDirectoryRoot);
-  </SDKReferenceDirectoryRoot>
-</PropertyGroup>
-```
+## Installation
+Install via the [Cordova CLI](https://cordova.apache.org/docs/en/edge/guide_cli_index.md.html).
+
+````bash
+cordova plugin add https://github.com/Thinkwise/cordova-plugin-websql.git
+````
+
+Or just install the [asynchronous IndexedDB plugin](https://github.com/ABB-Austin/cordova-plugin-indexeddb-async), which automatically installs this plugin as a dependency.
+
+
 ## Build
-The Windows and Windows Phone should be build separately. Note that the extra dashes are needed because of a bug in Apache Cordova.
-```bash
+The Windows and Windows Phone should be built separately. Note that the extra dashes are needed because of a bug in Apache Cordova.
+
+````bash
 cordova build windows --archs="x86 arm" -- --phone
 cordova build windows -- --win
-```
+````

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "cordova-plugin-websql-async",
+  "version": "1.0.0",
+  "description": "Web Sql Plugin for Apache Cordova (based on com.msopentech.websql)",
+  "cordova": {
+    "id": "cordova-plugin-websql-async",
+    "platforms": [
+      "windows"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Thinkwise/cordova-plugin-websql.git"
+  },
+  "keywords": [
+    "cordova",
+    "websql",
+    "ecosystem:cordova",
+    "cordova-windows8",
+    "cordova-windows",
+    "cordova-browser"
+  ],
+  "author": {
+    "name": "Thinkwise",
+    "url": "http://www.thinkwisesoftware.com"
+  }
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,27 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved. 
- Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
--->
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-xmlns:android="http://schemas.android.com/apk/res/android"
-           id="cordova-plugin-websql-async"
-      version="1.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
+    id="cordova-plugin-websql-async" version="1.0">
     <name>Web SQL plugin</name>
-
     <description>Web Sql Plugin for Apache Cordova (based on com.msopentech.websql)</description>
     <keywords>cordova, websql, db, database</keywords>
+    <author>Thinkwise</author>
+    <repo>https://github.com/Thinkwise/cordova-plugin-websql</repo>
+    <issues>https://github.com/Thinkwise/cordova-plugin-websql/issues</issues>
 
-    <platform name="windows">  
+    <platform name="windows">
+        <hook type="after_plugin_install" src="scripts/after_plugin_install.js"/>
+
         <js-module src="www/WebSQL.js" name="WebSQL">
             <clobbers target="window.WebSQL" />
         </js-module>
         <js-module src="www/windows/Database.js" name="Database" />
         <js-module src="www/windows/SqlTransaction.js" name="SqlTransaction" />
-
-        <!--<lib-file Include="Microsoft.VCLibs, Version=12.0" />
-        <lib-file Include="SQLite.WP81, Version=3.8.8.1" />-->
-
         <js-module src="src/windows/WebSqlProxy.js" name="WebSqlProxy">
             <runs />
         </js-module>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
 -->
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
-           id="com.thinkwisesoftware.websql"
+           id="cordova-plugin-websql-async"
       version="1.0">
     <name>Web SQL plugin</name>
 

--- a/scripts/after_plugin_install.js
+++ b/scripts/after_plugin_install.js
@@ -89,6 +89,11 @@ function limitProjectConfigurations(xml) {
  * Adds references to SQLite to the Windows Phone project file
  */
 function addSQLiteReferences(xml) {
+    // Don't do anything if the references are already in the file
+    if (xml.indexOf('cordova-plugin-websql-async') !== -1) {
+        return;
+    }
+
     // Find the last <Import/> element in the project file
     var lastImportStart = xml.lastIndexOf('<Import ');
     var lastImportEnd = xml.indexOf('/>', lastImportStart);

--- a/scripts/after_plugin_install.js
+++ b/scripts/after_plugin_install.js
@@ -1,0 +1,105 @@
+var path        = require('path'),
+    fs          = require('fs'),
+    pluginPath  = '',
+    windowsPath = '';
+
+/**
+ * This script modifies the Windows Phone project to work with SQLite.
+ */
+module.exports = function(context) {
+    try {
+        pluginPath = context.opts.plugin.pluginInfo.dir;
+        windowsPath = path.join(context.opts.projectRoot, 'platforms', 'windows');
+        modifySolutionFile();
+        modifyProjectFile();
+    }
+    catch (e) {
+        var err = new Error('An error occurred while adding SQLite to the Windows Phone project');
+        err.stack = e.stack;
+        throw err;
+    }
+};
+
+
+/**
+ * Modifies the Windows solution to work with SQLite.
+ */
+function modifySolutionFile() {
+    var solutionFilePath = path.join(windowsPath, 'CordovaApp.sln');
+    console.log('Adding SQLite to the Windows solution (%s)', solutionFilePath);
+
+    var sln = fs.readFileSync(solutionFilePath, {encoding: 'utf8'});
+    sln = limitSolutionConfigurations(sln);
+    fs.writeFileSync(solutionFilePath, sln);
+}
+
+
+/**
+ * Limits the Windows Phone project's configurations to ARM and x86, 
+ * which are the only ones supported by SQLite.
+ */
+function limitSolutionConfigurations(sln) {
+    var winPhoneProjGuid = '31B67A35-9503-4213-857E-F44EB42AE549';
+    if (sln.indexOf(winPhoneProjGuid) === -1) {
+        throw new Error('Unable to find the Windows Phone project GUID in the solution file');
+    }
+
+    var regex = new RegExp('(\\{' + winPhoneProjGuid + '\\})\\.(Debug|Release)\\|(Any CPU|x64)\\.(ActiveCfg|Build\\.0|Deploy\\.0) \\= (Debug|Release)\\|(Any CPU|x64)', 'g');
+    return sln.replace(regex, '$1.$2|$3.$4 = $5|x86');
+}
+
+
+/**
+ * Modifies the Windows Phone project to work with SQLite.
+ */
+function modifyProjectFile() {
+    var projectFilePath = path.join(windowsPath, 'CordovaApp.Phone.jsproj');
+    console.log('Adding SQLite to the Windows Phone project (%s)', projectFilePath);
+
+    var xml = fs.readFileSync(projectFilePath, {encoding: 'utf8'});
+    xml = limitProjectConfigurations(xml);
+    xml = addSQLiteReferences(xml);
+    fs.writeFileSync(projectFilePath, xml);
+}
+
+
+/**
+ * Limits the Windows Phone project's configurations to ARM and x86, 
+ * which are the only ones supported by SQLite.
+ */
+function limitProjectConfigurations(xml) {
+    // Find the ProjectConfigurations section in the project file
+    var configsStartTag = '<ItemGroup Label="ProjectConfigurations">';
+    var configsEndTag = '</ItemGroup>';
+    var configsStart = xml.lastIndexOf(configsStartTag);
+    var configsEnd = xml.indexOf(configsEndTag, configsStart);
+    if (configsStart === -1 || configsEnd === -1) {
+        throw new Error('Unable to find the <ItemGroup Label="ProjectConfigurations"> element in the project file');
+    }
+    configsStart += configsStartTag.length;
+
+    // Add project configurations
+    var configsPath = path.join(pluginPath, 'src', 'windows', 'configurations.xml');
+    var configs = fs.readFileSync(configsPath, {encoding: 'utf8'});
+    return xml.substring(0, configsStart) + '\n' + configs + xml.substring(configsEnd);
+}
+
+
+/**
+ * Adds references to SQLite to the Windows Phone project file
+ */
+function addSQLiteReferences(xml) {
+    // Find the last <Import/> element in the project file
+    var lastImportStart = xml.lastIndexOf('<Import ');
+    var lastImportEnd = xml.indexOf('/>', lastImportStart);
+    if (lastImportStart === -1 || lastImportEnd === -1) {
+        throw new Error('Unable to find an <Import/> element in the project file');
+    }
+    lastImportEnd += 2;
+
+    // Add SQLite references
+    var referencesPath = path.join(pluginPath, 'src', 'windows', 'references.xml');
+    var references = fs.readFileSync(referencesPath, {encoding: 'utf8'});
+    return xml.substring(0, lastImportEnd) + '\n' + references + xml.substring(lastImportEnd);
+}
+

--- a/src/windows/configurations.xml
+++ b/src/windows/configurations.xml
@@ -1,0 +1,16 @@
+    <ProjectConfiguration Include="Debug|x86">
+      <Configuration>Debug</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x86">
+      <Configuration>Release</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>

--- a/src/windows/references.xml
+++ b/src/windows/references.xml
@@ -1,0 +1,29 @@
+  <ItemGroup>
+    <SDKReference Include="Microsoft.VCLibs, Version=12.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <SDKReference Include="SQLite.WP81, Version=3.8.8.1" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="$(Platform) == 'x86'">
+      <ItemGroup>
+        <Reference Include="SQLitePluginNative">
+          <HintPath>..\..\plugins\cordova-plugin-websql-async\dist\x86\SQLitePluginNative.winmd</HintPath>
+          <IsWinMDFile>true</IsWinMDFile>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(Platform) == 'ARM'">
+      <ItemGroup>
+        <Reference Include="SQLitePluginNative">
+          <HintPath>..\..\plugins\cordova-plugin-websql-async\dist\ARM\SQLitePluginNative.winmd</HintPath>
+          <IsWinMDFile>true</IsWinMDFile>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <PropertyGroup>
+    <SDKReferenceDirectoryRoot>
+      ..\..\plugins\cordova-plugin-websql-async\src\windows\SDK\;$(SDKReferenceDirectoryRoot);
+    </SDKReferenceDirectoryRoot>
+  </PropertyGroup>

--- a/www/windows/Database.js
+++ b/www/windows/Database.js
@@ -87,7 +87,7 @@ Database.prototype.transaction = function (cb, onError, onSuccess, readOnly) {
                 cb(tx);
             } catch (cbEx) {
                 me.Log('Database.prototype.transaction callback error; lastTransactionId = ' + JSON.stringify(me.lastTransactionId) + '; err = ' + JSON.stringify(cbEx));
-                this.clearQueue();
+                tx.clearQueue();
             }
         });
 

--- a/www/windows/Database.js
+++ b/www/windows/Database.js
@@ -88,6 +88,9 @@ Database.prototype.transaction = function (cb, onError, onSuccess, readOnly) {
             } catch (cbEx) {
                 me.Log('Database.prototype.transaction callback error; lastTransactionId = ' + JSON.stringify(me.lastTransactionId) + '; err = ' + JSON.stringify(cbEx));
                 tx.clearQueue();
+                if (onError) {
+                    onError();
+                }
             }
         });
 

--- a/www/windows/SqlTransaction.js
+++ b/www/windows/SqlTransaction.js
@@ -58,7 +58,7 @@ SqlTransaction.prototype.executeSqlInternal = function (sql, params, onSuccess, 
             return res.rows[index];
         };
         // process rows to be W3C spec compliant; TODO - this must be done inside native part for performance reasons
-        for (idxRow = 0; idxRow < res.rows.length; idxRow++) {
+        for (var idxRow = 0; idxRow < res.rows.length; idxRow++) {
             var originalRow = res.rows[idxRow],
                 refinedRow = {},
                 idxColumn;


### PR DESCRIPTION
Hi @DickvdBrink and @Nimrodxx.  Thanks again for open-sourcing this plug-in.  I've created a [new IndexedDB plugin](https://github.com/ABB-Austin/cordova-plugin-indexeddb-async) that uses this plugin instead of the MSOpenTech one.   I also made a few changes to this plugin to simplify the installation process.   Here are the changes I made:
1. Added an `after_plugin_install` hook that takes care of modifying the `.jsproj` and `.sln` files, so now there aren't any manual post-installation steps
2. Updated the ReadMe file to get rid of the manual installation steps, included the Cordova CLI installation command, and linked to the async IndexedDB plugin
3. Cordova is [moving all plugins to npm](https://github.com/cordova/apache-blog-posts/blob/master/2015-04-15-plugins-release-and-move-to-npm.md), so I added a `package.json` file and renamed the plugin according to the new naming convention (`cordova-plugin-websql-async`).  You can publish the plugin to npm using the `npm publish` command.  Let me know once you've done that, and I'll update the IndexedDB plugin to point to your npm package.
