### PR TITLE
seal class to pass Windows App Certification Kit

### DIFF
--- a/src/windows/SQLite/SQLiteCommand.cs
+++ b/src/windows/SQLite/SQLiteCommand.cs
@@ -11,7 +11,7 @@ using System.Collections;
 
 namespace SQLitePluginNative.SQLite
 {
-    public partial class SQLiteCommand
+    public sealed partial class SQLiteCommand
     {
         SQLiteConnection _conn;
         private List<Binding> _bindings;


### PR DESCRIPTION
Without this change, the Windows App Certification Kit gives a report containing the following error.

Error Found:
The general metadata correctness test detected the following errors:
  ◦Type SQLitePluginNative.SQLite.SQLiteCommand in file SQLitePluginNative.winmd is not sealed and does not have the ComposableAttribute. Unsealed types must have ComposableAttribute.

This error prevents deployment to the Windows Phone Store.
